### PR TITLE
feat: Add middleware to check both roles and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ class User extends Model {
   ...
   static get traits () {
     return [
-      '@provider:Adonis/Acl/HasRole',
-      '@provider:Adonis/Acl/HasPermission'
+      '@provider:Rocketseat/Acl/HasRole',
+      '@provider:Rocketseat/Acl/HasPermission'
     ]
   }
   ...
@@ -51,8 +51,9 @@ class User extends Model {
 ```js
 const namedMiddleware = {
   ...
-  is: 'Adonis/Acl/Is',
-  can: 'Adonis/Acl/Can',
+  is: 'Rocketseat/Acl/Is',
+  can: 'Rocketseat/Acl/Can',
+  acl: 'Rocketseat/Acl/Acl',
   ...
 }
 ```
@@ -62,7 +63,7 @@ For using in views
 ```js
 const globalMiddleware = [
   ...
-  'Adonis/Acl/Init'
+  'Rocketseat/Acl/Init'
   ...
 ]
 ```
@@ -84,12 +85,14 @@ const roleAdmin = new Role();
 roleAdmin.name = "Administrator";
 roleAdmin.slug = "administrator";
 roleAdmin.description = "manage administration privileges";
+
 await roleAdmin.save();
 
 const roleModerator = new Role();
 roleModerator.name = "Moderator";
 roleModerator.slug = "moderator";
 roleModerator.description = "manage moderator privileges";
+
 await roleModerator.save();
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ const namedMiddleware = {
   is: 'Rocketseat/Acl/Is',
   can: 'Rocketseat/Acl/Can',
   acl: 'Rocketseat/Acl/Acl',
+  scope: 'Rocketseat/Acl/Scope'
   ...
 }
 ```
@@ -96,7 +97,7 @@ roleModerator.description = "manage moderator privileges";
 await roleModerator.save();
 ```
 
-Before, You should do first, use the `HasRole` trait in Your `User` Model.
+Before, you should do first, use the `HasRole` trait in Your `User` Model.
 
 ```js
 class User extends Model {
@@ -163,7 +164,7 @@ readUsersPermission.description = "read users permission";
 await readUsersPermission.save();
 ```
 
-Before, You should do first, use the `HasPermission` trait in Your `User` Model.
+Before, you should do first, use the `HasPermission` trait in Your `User` Model.
 
 ```js
 class User extends Model {
@@ -243,9 +244,56 @@ Route.get("/users").middleware([
 // check permissions
 Route.get("/posts").middleware(["auth:jwt", "can:read_posts"]);
 
+// check roles and permissions
+Route.put("/posts").middleware(["auth:jwt", "acl:admin or update_posts"]);
+
 // scopes (using permissions table for scopes)
 Route.get("/posts").middleware(["auth:jwt", "scope:posts.*"]);
 ```
+The `acl` **middleware** is used to verify both a role and a permission at the same time, but for it to work properly it is necessary that a `role` and a `permission` doesn't share the same name.
+
+## Vow trait
+
+`adonis-acl` has a `trait` to make it easy to use it while testing with `adonis-vow`. To enable the `addRoles` and `addPermissions` methods, you need to add the trait `Acl/Client`.
+
+The arguments must be your roles or permissions.
+
+```js
+const [admin, moderator] = await Role.all();
+addRole(admin, moderator);
+```
+
+```js
+const [create, read, update, del] = await Permission.all();
+addPermission(create, read, update, del);
+```
+
+Here's an example of how to use it inside a test:
+
+```js
+const { test, trait } = use("Test/Suite")("Awesome test");
+
+trait("Test/ApiClient");
+trait("Auth/Client");
+trait("Acl/Client");
+
+test("awesome some test", async ({ client }) => {
+  const role = await Role.find(1);
+  const permission = await Permission.find(1);
+  const user = await User.find(1);
+
+  const response = await client
+    .put("/posts/1")
+    .loginVia(user)
+    .addRoles(role)
+    .addPermissions(permission)
+    .end();
+});
+```
+
+Both `addRoles` and `addPermissions` inject roles and permissions on the user that was passed by `loginVia` method, so it is vital to call them after `loginVia` as seen on the example above.
+
+It is also crucial that `trait("Auth/Client")` is called before `trait("Acl/Client")`.
 
 ## Using commands
 

--- a/commands/templates/create_permission_schema.mustache
+++ b/commands/templates/create_permission_schema.mustache
@@ -2,7 +2,7 @@
 
 const Schema = use('Schema')
 
-class PermissionsSchema extends Schema {
+class PermissionSchema extends Schema {
   up () {
     this.create('permissions', table => {
       table.increments()
@@ -18,4 +18,4 @@ class PermissionsSchema extends Schema {
   }
 }
 
-module.exports = PermissionsSchema
+module.exports = PermissionSchema

--- a/commands/templates/create_role_schema.mustache
+++ b/commands/templates/create_role_schema.mustache
@@ -18,4 +18,4 @@ class RoleSchema extends Schema {
   }
 }
 
-module.exports = RolesSchema
+module.exports = RoleSchema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketseat/adonis-acl",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Adonis ACL system",
   "main": "src/Acl/index.js",
   "directories": {

--- a/providers/AclProvider.js
+++ b/providers/AclProvider.js
@@ -60,6 +60,11 @@ class AclProvider extends ServiceProvider {
       return new Scope()
     })
 
+    this.app.bind('Adonis/Acl/Acl', () => {
+      const Acl = require('../src/Middlewares/Acl')
+      return new Acl()
+    })
+
     this.app.bind('Adonis/Traits/Acl', (app) => {
       return ({ Request, traits }) => {
         const authIndex = findIndex(traits, (trait) => trait.action === 'Auth/Client')

--- a/src/Acl/index.js
+++ b/src/Acl/index.js
@@ -13,6 +13,29 @@ const Acl = exports = module.exports = {}
 
 Acl.check = check
 
+const normalizeExpression = (keys, tag, expression) => {
+  let newExpression = expression
+  keys.forEach((key) => {
+    newExpression = newExpression.replace(new RegExp(key, 'g'), `${tag}-${key}`)
+  })
+
+  return newExpression
+}
+
+Acl.checkAdvanced = (expression, rolesProvided, permissionsProvided) => {
+  const roles = rolesProvided.map(role => `role-${role}`)
+  const permissions = permissionsProvided.map(permission => `perm-${permission}`)
+
+  const acl = [...roles, ...permissions]
+
+  let normalizedExpression = normalizeExpression(rolesProvided, 'role', expression)
+  normalizedExpression = normalizeExpression(permissionsProvided, 'perm', normalizedExpression)
+
+  return check(normalizedExpression, operand => {
+    return acl.includes(operand)
+  })
+}
+
 Acl.validateScope = (required, provided) => {
   return _.every(required, (scope) => {
     return _.some(provided, (permission) => {

--- a/src/Middlewares/Acl.js
+++ b/src/Middlewares/Acl.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * adonis-acl
+ * Copyright(c) 2017 Evgeny Razumov
+ * MIT Licensed
+ */
+const Acl = require('../Acl')
+const ForbiddenException = require('../Exceptions/ForbiddenException')
+
+class AclMiddleware {
+  async handle ({ auth }, next, ...args) {
+    let expression = args[0]
+    if (Array.isArray(expression)) {
+      expression = expression[0]
+    }
+
+    const roles = await auth.user.getRoles()
+    const permissions = await auth.user.getPermissions()
+
+    const acl = Acl.checkAdvanced(expression, roles, permissions)
+
+    if (!acl) {
+      throw new ForbiddenException()
+    }
+
+    await next()
+  }
+}
+
+module.exports = AclMiddleware

--- a/test/unit/middlewares.spec.js
+++ b/test/unit/middlewares.spec.js
@@ -9,8 +9,98 @@
 const test = require('japa')
 const Is = require('../../src/Middlewares/Is')
 const Can = require('../../src/Middlewares/Can')
+const Acl = require('../../src/Middlewares/Acl')
 const Scope = require('../../src/Middlewares/Scope')
 const Init = require('../../src/Middlewares/Init')
+
+test.group('Acl Middleware', function () {
+  test('should allow, when first arg is string', async (assert) => {
+    const fakeRequest = {
+      auth: {
+        user: {
+          getRoles () {
+            return ['any-role']
+          },
+          getPermissions () {
+            return ['any-permission']
+          }
+        }
+      }
+    }
+
+    const acl = new Acl()
+    await acl.handle(fakeRequest, () => {
+      return assert.isTrue(true)
+    }, 'any-role && any-permission')
+  })
+
+  test('should allow, when first arg is array', async (assert) => {
+    const fakeRequest = {
+      auth: {
+        user: {
+          getRoles () {
+            return ['any-role']
+          },
+          getPermissions () {
+            return ['any-permission']
+          }
+        }
+      }
+    }
+
+    const acl = new Acl()
+    await acl.handle(fakeRequest, () => {
+      return assert.isTrue(true)
+    }, ['any-role && any-permission'])
+  })
+
+  test('should throw error, when first arg is string', async (assert) => {
+    try {
+      const fakeRequest = {
+        auth: {
+          user: {
+            getRoles () {
+              return []
+            },
+            getPermissions () {
+              return []
+            }
+          }
+        }
+      }
+
+      const acl = new Acl()
+      await acl.handle(fakeRequest, () => { }, 'any-role && any-permission')
+    } catch (e) {
+      console.log(e)
+      assert.equal(e.name, 'ForbiddenException')
+      assert.equal(e.message, 'Access forbidden. You are not allowed to this resource.')
+    }
+  })
+
+  test('should throw error, when first arg is array', async (assert) => {
+    try {
+      const fakeRequest = {
+        auth: {
+          user: {
+            getRoles () {
+              return []
+            },
+            getPermissions () {
+              return []
+            }
+          }
+        }
+      }
+
+      const acl = new Acl()
+      await acl.handle(fakeRequest, () => { }, ['any-role && any-permission'])
+    } catch (e) {
+      assert.equal(e.name, 'ForbiddenException')
+      assert.equal(e.message, 'Access forbidden. You are not allowed to this resource.')
+    }
+  })
+})
 
 test.group('Can Middleware', function () {
   test('should allow, when first arg is string', async (assert) => {


### PR DESCRIPTION
We now have the `acl` middleware which can be used to check both roles and permissions simultaneously in the same route/group.

The only caveat is that this way, roles and permissions cannot share the same name anymore.