### PR TITLE
docs: Fix command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ const globalMiddleware = [
 ]
 ```
 
-6. Publish the package migrations to your application and run these with `adonis migrations:run`.
+6. Publish the package migrations to your application and run these with `adonis migration:run`.
 
 ```bash
 $ adonis acl:setup


### PR DESCRIPTION
The instructions on README had a wrong command which does not exists.

`migrations:run` -> `migration:run`

Closes #3 