### PR TITLE
chore: Fix timestamps in permissions and roles

### DIFF
--- a/src/Models/Permission.js
+++ b/src/Models/Permission.js
@@ -18,7 +18,7 @@ class Permission extends Model {
   }
 
   users () {
-    return this.belongsToMany('App/Models/User').pivotTable('users_permissions')
+    return this.belongsToMany('App/Models/User').pivotTable('users_permissions').withTimestamps()
   }
 }
 

--- a/src/Models/Role.js
+++ b/src/Models/Role.js
@@ -18,7 +18,7 @@ class Role extends Model {
   }
 
   permissions () {
-    return this.belongsToMany('Adonis/Acl/Permission').pivotTable('roles_permissions')
+    return this.belongsToMany('Adonis/Acl/Permission').pivotTable('roles_permissions').withTimestamps()
   }
 
   async getPermissions () {

--- a/src/Traits/HasPermission.js
+++ b/src/Traits/HasPermission.js
@@ -12,7 +12,7 @@ const Acl = require('../Acl')
 module.exports = class HasPermission {
   register (Model) {
     Model.prototype.permissions = function () {
-      return this.belongsToMany('Adonis/Acl/Permission').pivotTable('users_permissions')
+      return this.belongsToMany('Adonis/Acl/Permission').pivotTable('users_permissions').withTimestamps()
     }
 
     Model.prototype.getPermissions = async function () {

--- a/src/Traits/HasRole.js
+++ b/src/Traits/HasRole.js
@@ -12,7 +12,7 @@ const Acl = require('../Acl')
 module.exports = class HasRole {
   register (Model) {
     Model.prototype.roles = function () {
-      return this.belongsToMany('Adonis/Acl/Role').pivotTable('users_roles')
+      return this.belongsToMany('Adonis/Acl/Role').pivotTable('users_roles').withTimestamps()
     }
 
     Model.prototype.getRoles = async function () {


### PR DESCRIPTION
This PR resolves the error when saving a `permission` or `role`, saving without the `timestamps` of `created_at` and `updated_at`.